### PR TITLE
Don't use stack static stack memory for the client ID.  async-mqtt-cl…

### DIFF
--- a/lib/MQTT/MqttClient.cpp
+++ b/lib/MQTT/MqttClient.cpp
@@ -77,10 +77,9 @@ void MqttClient::begin() {
   mqttClient.setKeepAlive(60);
 
   // Configure client
-  char nameBuffer[30];
-  sprintf_P(nameBuffer, PSTR("epaper-display-%u"), ESP_CHIP_ID());
+  sprintf_P(this->clientName, PSTR("epaper-display-%u"), ESP_CHIP_ID());
+  mqttClient.setClientId(this->clientName);
 
-  mqttClient.setClientId(nameBuffer);
   if (this->username.length() > 0) {
     mqttClient.setCredentials(this->username.c_str(), this->password.c_str());
   }

--- a/lib/MQTT/MqttClient.h
+++ b/lib/MQTT/MqttClient.h
@@ -42,6 +42,7 @@ private:
   String domain;
   String username;
   String password;
+  char clientName[30];
 
   unsigned long lastConnectAttempt;
   TVariableUpdateFn variableUpdateCallback;


### PR DESCRIPTION
…ient doesn't make a copy.